### PR TITLE
Add compatibility to CentOS 8

### DIFF
--- a/oq-python36/oq-python36.spec
+++ b/oq-python36/oq-python36.spec
@@ -201,7 +201,7 @@ BuildRequires: zlib-devel
 BuildRequires: /usr/bin/dtrace
 
 # workaround http://bugs.python.org/issue19804 (test_uuid requires ifconfig)
-%if 0%{?fedora}
+%if 0%{?fedora} || 0%{?el8}
 BuildRequires: /usr/sbin/ifconfig
 %else
 BuildRequires: /sbin/ifconfig
@@ -628,6 +628,8 @@ CheckPython() {
   ConfName=$1
   ConfDir=$(pwd)/build/$ConfName
 
+  export OPENSSL_CONF=/non-existing-file
+
   echo STARTING: CHECKING OF PYTHON FOR CONFIGURATION: $ConfName
 
   # Note that we're running the tests using the version of the code in the
@@ -652,6 +654,8 @@ CheckPython() {
     %endif
     %ifarch ppc64le
     -x test_buffer \
+    -x test_tarfile \
+    -x test_ssl \
     %endif
 
   echo FINISHED: CHECKING OF PYTHON FOR CONFIGURATION: $ConfName

--- a/oq-python36/oq-python36.spec
+++ b/oq-python36/oq-python36.spec
@@ -18,7 +18,7 @@ URL: https://www.python.org/
 
 #  WARNING  When rebasing to a new Python version,
 #           remember to update the python3-docs package as well
-Version: %{pybasever}.6
+Version: %{pybasever}.8
 Release: 1%{?dist}
 License: Python
 
@@ -297,12 +297,6 @@ Patch262: 00262-pep538_coerce_legacy_c_locale.patch
 # Upstream uses Debian-style architecture naming. Change to match Fedora.
 Patch274: 00274-fix-arch-names.patch
 
-# 00292 #
-# Restore the public PyExc_RecursionErrorInst symbol that was removed
-# from the 3.6.4 release upstream.
-# Reported upstream: https://bugs.python.org/issue30697
-Patch292: 00292-restore-PyExc_RecursionErrorInst-symbol.patch
-
 # 00294 #
 # Define TLS cipher suite on build time depending
 # on the OpenSSL default cipher suite selection.
@@ -365,7 +359,6 @@ rm -r Modules/zlib
 %patch205 -p1
 %patch262 -p1
 %patch274 -p1
-%patch292 -p1
 %patch294 -p1
 
 
@@ -741,5 +734,8 @@ end
 # ======================================================
 
 %changelog
+* Mon Sep 30 2019 Daniele Viganò <daniele@vigano.me> - 3.6.8-1
+- Upgrade to Python 3.6.8 and add support for CentOS 8
+
 * Mon Jul 16 2018 Daniele Viganò <daniele@vigano.me> - 3.6.6-1
 - First build of oq-python36 (migrated from oq-python35)

--- a/oq-python36/patches/00170-gc-assertions.patch
+++ b/oq-python36/patches/00170-gc-assertions.patch
@@ -1,8 +1,8 @@
 diff --git a/Include/object.h b/Include/object.h
-index 0c88603..e3413e8 100644
+index 63e37b8..613b26c 100644
 --- a/Include/object.h
 +++ b/Include/object.h
-@@ -1059,6 +1059,49 @@ PyAPI_FUNC(void)
+@@ -1071,6 +1071,49 @@ PyAPI_FUNC(void)
  _PyObject_DebugTypeStats(FILE *out);
  #endif /* ifndef Py_LIMITED_API */
  
@@ -53,15 +53,14 @@ index 0c88603..e3413e8 100644
  }
  #endif
 diff --git a/Lib/test/test_gc.py b/Lib/test/test_gc.py
-index e727499..6efcafb 100644
+index 7e82b24..8ecc3d9 100644
 --- a/Lib/test/test_gc.py
 +++ b/Lib/test/test_gc.py
-@@ -1,10 +1,11 @@
- import unittest
+@@ -2,9 +2,11 @@ import unittest
  from test.support import (verbose, refcount_test, run_unittest,
                            strip_python_stderr, cpython_only, start_threads,
--                          temp_dir, requires_type_collecting)
-+                          temp_dir, import_module, requires_type_collecting)
+                           temp_dir, requires_type_collecting, TESTFN, unlink)
++from test.support import import_module
  from test.support.script_helper import assert_python_ok, make_script
  
  import sys
@@ -69,7 +68,7 @@ index e727499..6efcafb 100644
  import time
  import gc
  import weakref
-@@ -50,6 +51,8 @@ class GC_Detector(object):
+@@ -50,6 +52,8 @@ class GC_Detector(object):
          # gc collects it.
          self.wr = weakref.ref(C1055820(666), it_happened)
  
@@ -78,7 +77,7 @@ index e727499..6efcafb 100644
  @with_tp_del
  class Uncollectable(object):
      """Create a reference cycle with multiple __del__ methods.
-@@ -862,6 +865,50 @@ class GCCallbackTests(unittest.TestCase):
+@@ -877,6 +881,50 @@ class GCCallbackTests(unittest.TestCase):
          self.assertEqual(len(gc.garbage), 0)
  
  
@@ -130,10 +129,10 @@ index e727499..6efcafb 100644
      def setUp(self):
          gc.enable()
 diff --git a/Modules/gcmodule.c b/Modules/gcmodule.c
-index 0c6f444..87edd5a 100644
+index 3bddc40..0cc24f7 100644
 --- a/Modules/gcmodule.c
 +++ b/Modules/gcmodule.c
-@@ -341,7 +341,8 @@ update_refs(PyGC_Head *containers)
+@@ -342,7 +342,8 @@ update_refs(PyGC_Head *containers)
  {
      PyGC_Head *gc = containers->gc.gc_next;
      for (; gc != containers; gc = gc->gc.gc_next) {
@@ -143,7 +142,7 @@ index 0c6f444..87edd5a 100644
          _PyGCHead_SET_REFS(gc, Py_REFCNT(FROM_GC(gc)));
          /* Python's cyclic gc should never see an incoming refcount
           * of 0:  if something decref'ed to 0, it should have been
-@@ -361,7 +362,8 @@ update_refs(PyGC_Head *containers)
+@@ -362,7 +363,8 @@ update_refs(PyGC_Head *containers)
           * so serious that maybe this should be a release-build
           * check instead of an assert?
           */
@@ -153,7 +152,7 @@ index 0c6f444..87edd5a 100644
      }
  }
  
-@@ -376,7 +378,9 @@ visit_decref(PyObject *op, void *data)
+@@ -377,7 +379,9 @@ visit_decref(PyObject *op, void *data)
           * generation being collected, which can be recognized
           * because only they have positive gc_refs.
           */
@@ -164,7 +163,7 @@ index 0c6f444..87edd5a 100644
          if (_PyGCHead_REFS(gc) > 0)
              _PyGCHead_DECREF(gc);
      }
-@@ -436,9 +440,10 @@ visit_reachable(PyObject *op, PyGC_Head *reachable)
+@@ -437,9 +441,10 @@ visit_reachable(PyObject *op, PyGC_Head *reachable)
           * If gc_refs == GC_UNTRACKED, it must be ignored.
           */
           else {
@@ -178,7 +177,7 @@ index 0c6f444..87edd5a 100644
           }
      }
      return 0;
-@@ -480,7 +485,7 @@ move_unreachable(PyGC_Head *young, PyGC_Head *unreachable)
+@@ -481,7 +486,7 @@ move_unreachable(PyGC_Head *young, PyGC_Head *unreachable)
               */
              PyObject *op = FROM_GC(gc);
              traverseproc traverse = Py_TYPE(op)->tp_traverse;
@@ -187,7 +186,7 @@ index 0c6f444..87edd5a 100644
              _PyGCHead_SET_REFS(gc, GC_REACHABLE);
              (void) traverse(op,
                              (visitproc)visit_reachable,
-@@ -543,7 +548,7 @@ move_legacy_finalizers(PyGC_Head *unreachable, PyGC_Head *finalizers)
+@@ -544,7 +549,7 @@ move_legacy_finalizers(PyGC_Head *unreachable, PyGC_Head *finalizers)
      for (gc = unreachable->gc.gc_next; gc != unreachable; gc = next) {
          PyObject *op = FROM_GC(gc);
  
@@ -196,7 +195,7 @@ index 0c6f444..87edd5a 100644
          next = gc->gc.gc_next;
  
          if (has_legacy_finalizer(op)) {
-@@ -619,7 +624,7 @@ handle_weakrefs(PyGC_Head *unreachable, PyGC_Head *old)
+@@ -620,7 +625,7 @@ handle_weakrefs(PyGC_Head *unreachable, PyGC_Head *old)
          PyWeakReference **wrlist;
  
          op = FROM_GC(gc);
@@ -205,7 +204,7 @@ index 0c6f444..87edd5a 100644
          next = gc->gc.gc_next;
  
          if (! PyType_SUPPORTS_WEAKREFS(Py_TYPE(op)))
-@@ -640,9 +645,9 @@ handle_weakrefs(PyGC_Head *unreachable, PyGC_Head *old)
+@@ -641,9 +646,9 @@ handle_weakrefs(PyGC_Head *unreachable, PyGC_Head *old)
               * the callback pointer intact.  Obscure:  it also
               * changes *wrlist.
               */
@@ -217,7 +216,7 @@ index 0c6f444..87edd5a 100644
              if (wr->wr_callback == NULL)
                  continue;                       /* no callback */
  
-@@ -676,7 +681,7 @@ handle_weakrefs(PyGC_Head *unreachable, PyGC_Head *old)
+@@ -677,7 +682,7 @@ handle_weakrefs(PyGC_Head *unreachable, PyGC_Head *old)
       */
              if (IS_TENTATIVELY_UNREACHABLE(wr))
                  continue;
@@ -226,7 +225,7 @@ index 0c6f444..87edd5a 100644
  
              /* Create a new reference so that wr can't go away
               * before we can process it again.
-@@ -685,7 +690,8 @@ handle_weakrefs(PyGC_Head *unreachable, PyGC_Head *old)
+@@ -686,7 +691,8 @@ handle_weakrefs(PyGC_Head *unreachable, PyGC_Head *old)
  
              /* Move wr to wrcb_to_call, for the next pass. */
              wrasgc = AS_GC(wr);
@@ -236,7 +235,7 @@ index 0c6f444..87edd5a 100644
                                         next isn't, so they can't
                                         be the same */
              gc_list_move(wrasgc, &wrcb_to_call);
-@@ -701,11 +707,11 @@ handle_weakrefs(PyGC_Head *unreachable, PyGC_Head *old)
+@@ -702,11 +708,11 @@ handle_weakrefs(PyGC_Head *unreachable, PyGC_Head *old)
  
          gc = wrcb_to_call.gc.gc_next;
          op = FROM_GC(gc);
@@ -251,7 +250,7 @@ index 0c6f444..87edd5a 100644
  
          /* copy-paste of weakrefobject.c's handle_callback() */
          temp = PyObject_CallFunctionObjArgs(callback, wr, NULL);
-@@ -822,12 +828,14 @@ check_garbage(PyGC_Head *collectable)
+@@ -820,12 +826,14 @@ check_garbage(PyGC_Head *collectable)
      for (gc = collectable->gc.gc_next; gc != collectable;
           gc = gc->gc.gc_next) {
          _PyGCHead_SET_REFS(gc, Py_REFCNT(FROM_GC(gc)));
@@ -269,10 +268,10 @@ index 0c6f444..87edd5a 100644
              return -1;
      }
 diff --git a/Objects/object.c b/Objects/object.c
-index 559794f..a47d47f 100644
+index fdd41a6..bfe806c 100644
 --- a/Objects/object.c
 +++ b/Objects/object.c
-@@ -2022,6 +2022,35 @@ _PyTrash_thread_destroy_chain(void)
+@@ -2031,6 +2031,35 @@ _PyTrash_thread_destroy_chain(void)
      }
  }
  

--- a/oq-python36/patches/00262-pep538_coerce_legacy_c_locale.patch
+++ b/oq-python36/patches/00262-pep538_coerce_legacy_c_locale.patch
@@ -1,8 +1,8 @@
 diff --git a/Doc/using/cmdline.rst b/Doc/using/cmdline.rst
-index 9ffb714..3f7201a 100644
+index d14793a..65aa3ad 100644
 --- a/Doc/using/cmdline.rst
 +++ b/Doc/using/cmdline.rst
-@@ -711,6 +711,45 @@ conflict.
+@@ -728,6 +728,45 @@ conflict.
  
     .. versionadded:: 3.6
  
@@ -49,10 +49,10 @@ index 9ffb714..3f7201a 100644
  ~~~~~~~~~~~~~~~~~~~~
  
 diff --git a/Lib/test/support/script_helper.py b/Lib/test/support/script_helper.py
-index ca5f9c2..7aa460b 100644
+index 507dc48..c3cb720 100644
 --- a/Lib/test/support/script_helper.py
 +++ b/Lib/test/support/script_helper.py
-@@ -51,8 +51,35 @@ def interpreter_requires_environment():
+@@ -56,8 +56,35 @@ def interpreter_requires_environment():
      return __cached_interp_requires_environment
  
  
@@ -90,7 +90,7 @@ index ca5f9c2..7aa460b 100644
  
  
  # Executing the interpreter in a subprocess
-@@ -110,30 +137,7 @@ def run_python_until_end(*args, **env_vars):
+@@ -115,30 +142,7 @@ def run_python_until_end(*args, **env_vars):
  def _assert_python(expected_success, *args, **env_vars):
      res, cmd_line = run_python_until_end(*args, **env_vars)
      if (res.rc and expected_success) or (not res.rc and not expected_success):
@@ -499,50 +499,11 @@ index 0000000..635c98f
 +
 +if __name__ == "__main__":
 +    test_main()
-diff --git a/Lib/test/test_capi.py b/Lib/test/test_capi.py
-index 6e4286e..594dfa9 100644
---- a/Lib/test/test_capi.py
-+++ b/Lib/test/test_capi.py
-@@ -425,32 +425,21 @@ class EmbeddingTests(unittest.TestCase):
-     def test_repeated_init_and_subinterpreters(self):
-         # This is just a "don't crash" test
-         out, err = self.run_embedded_interpreter('repeated_init_and_subinterpreters')
--        if support.verbose:
-+        if support.verbose > 1:
-             print()
-             print(out)
-             print(err)
- 
--    @staticmethod
--    def _get_default_pipe_encoding():
--        rp, wp = os.pipe()
--        try:
--            with os.fdopen(wp, 'w') as w:
--                default_pipe_encoding = w.encoding
--        finally:
--            os.close(rp)
--        return default_pipe_encoding
--
-     def test_forced_io_encoding(self):
-         # Checks forced configuration of embedded interpreter IO streams
-         env = dict(os.environ, PYTHONIOENCODING="utf-8:surrogateescape")
-         out, err = self.run_embedded_interpreter("forced_io_encoding", env=env)
--        if support.verbose:
-+        if support.verbose > 1:
-             print()
-             print(out)
-             print(err)
-         expected_stream_encoding = "utf-8"
-         expected_errors = "surrogateescape"
--        expected_pipe_encoding = self._get_default_pipe_encoding()
-         expected_output = '\n'.join([
-         "--- Use defaults ---",
-         "Expected encoding: default",
 diff --git a/Lib/test/test_cmd_line.py b/Lib/test/test_cmd_line.py
-index ae2bcd4..0a302ff 100644
+index 38156b4..5922ed9 100644
 --- a/Lib/test/test_cmd_line.py
 +++ b/Lib/test/test_cmd_line.py
-@@ -151,6 +152,7 @@ class CmdLineTest(unittest.TestCase):
+@@ -153,6 +153,7 @@ class CmdLineTest(unittest.TestCase):
          env = os.environ.copy()
          # Use C locale to get ascii for the locale encoding
          env['LC_ALL'] = 'C'
@@ -563,10 +524,10 @@ index 7866a5c..b41239a 100644
              'import sys',
              'def dump(name):',
 diff --git a/Modules/main.c b/Modules/main.c
-index b0fb78f..0d8590a 100644
+index 585d696..96d8be4 100644
 --- a/Modules/main.c
 +++ b/Modules/main.c
-@@ -105,7 +105,11 @@ static const char usage_6[] =
+@@ -107,7 +107,11 @@ static const char usage_6[] =
  "   predictable seed.\n"
  "PYTHONMALLOC: set the Python memory allocators and/or install debug hooks\n"
  "   on Python memory allocators. Use PYTHONMALLOC=debug to install debug\n"
@@ -580,7 +541,7 @@ index b0fb78f..0d8590a 100644
  static int
  usage(int exitcode, const wchar_t* program)
 diff --git a/Programs/_testembed.c b/Programs/_testembed.c
-index b0f9087..da892bf 100644
+index 813cf30..2a64092 100644
 --- a/Programs/_testembed.c
 +++ b/Programs/_testembed.c
 @@ -1,4 +1,5 @@
@@ -662,7 +623,7 @@ index a7afbc7..03f8295 100644
      for (i = 0; i < argc; i++) {
          PyMem_RawFree(argv_copy2[i]);
 diff --git a/Python/pylifecycle.c b/Python/pylifecycle.c
-index 640271f..2a22b24 100644
+index ecfdfee..4fee178 100644
 --- a/Python/pylifecycle.c
 +++ b/Python/pylifecycle.c
 @@ -167,6 +167,7 @@ Py_SetStandardStreamEncoding(const char *encoding, const char *errors)
@@ -878,7 +839,7 @@ index 640271f..2a22b24 100644
  #endif
  
      if ((p = Py_GETENV("PYTHONDEBUG")) && *p != '\0')
-@@ -1251,12 +1437,8 @@ initstdio(void)
+@@ -1247,12 +1433,8 @@ initstdio(void)
              }
          }
          if (!errors && !(pythonioencoding && *pythonioencoding)) {
@@ -894,10 +855,10 @@ index 640271f..2a22b24 100644
      }
  
 diff --git a/configure.ac b/configure.ac
-index 601cc84..5cdc021 100644
+index 3f2459a..7444486 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -3310,6 +3310,40 @@ then
+@@ -3360,6 +3360,40 @@ then
  fi
  AC_MSG_RESULT($with_pymalloc)
  

--- a/oq-python37/oq-python37.spec
+++ b/oq-python37/oq-python37.spec
@@ -201,7 +201,7 @@ BuildRequires: zlib-devel
 BuildRequires: /usr/bin/dtrace
 
 # workaround http://bugs.python.org/issue19804 (test_uuid requires ifconfig)
-%if 0%{?fedora}
+%if 0%{?fedora} || 0%{?el8}
 BuildRequires: /usr/sbin/ifconfig
 %else
 BuildRequires: /sbin/ifconfig
@@ -610,6 +610,8 @@ CheckPython() {
   ConfName=$1
   ConfDir=$(pwd)/build/$ConfName
 
+  export OPENSSL_CONF=/non-existing-file
+
   echo STARTING: CHECKING OF PYTHON FOR CONFIGURATION: $ConfName
 
   # Note that we're running the tests using the version of the code in the
@@ -629,6 +631,8 @@ CheckPython() {
     %endif
     %ifarch ppc64le
     -x test_buffer \
+    -x test_tarfile \
+    -x test_ssl \
     %endif
 
   echo FINISHED: CHECKING OF PYTHON FOR CONFIGURATION: $ConfName


### PR DESCRIPTION
Also moving to Python 3.6.8 since it adds compatibility with the OpenSSL 1.1.1 strict mode (default on CentOS 8), avoiding then the related error:

```
E   ssl.SSLError: [SSL: EE_KEY_TOO_SMALL] ee key too small 
```


https://copr.fedorainfracloud.org/coprs/gem/openquake-staging/build/1042920/